### PR TITLE
Upgrade to Open Enclave 0.11

### DIFF
--- a/tests/enclave/CMakeLists.txt
+++ b/tests/enclave/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_custom_command(OUTPUT tests_t.h tests_t.c tests_args.h
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../tests.edl
-    COMMAND openenclave::oeedger8r --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../tests.edl)
+    COMMAND openenclave::oeedger8r
+    --search-path ${OE_INCLUDEDIR}
+    --search-path ${OE_INCLUDEDIR}/openenclave/edl/sgx
+    --trusted ${CMAKE_CURRENT_SOURCE_DIR}/../tests.edl)
 
 add_executable(tests.enclave
     enclave.cpp

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_custom_command(OUTPUT tests_u.h tests_u.c tests_args.h
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/../tests.edl
-    COMMAND openenclave::oeedger8r --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../tests.edl)
+    COMMAND openenclave::oeedger8r
+    --search-path ${OE_INCLUDEDIR}
+    --search-path ${OE_INCLUDEDIR}/openenclave/edl/sgx
+    --untrusted ${CMAKE_CURRENT_SOURCE_DIR}/../tests.edl)
 
 add_executable(tests.host
     host.cpp
@@ -9,4 +12,4 @@ add_executable(tests.host
 # Needed for the generated file tests_u.h
 target_include_directories(tests.host PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
-target_link_libraries(tests.host openenclave::oehostapp)
+target_link_libraries(tests.host openenclave::oehost)

--- a/tests/tests.edl
+++ b/tests/tests.edl
@@ -1,5 +1,7 @@
-
 enclave {
+    from "openenclave/edl/syscall.edl" import *;
+    from "platform.edl" import *;
+
     trusted {
         public void enclave_run_tests();
     };


### PR DESCRIPTION
Changes necessary to build and run against latest Open Enclave (0.11).

```
(env) amchamay@amchamay2:/data/amchamay/openenclave-curl/build$ make
[  5%] Performing build step for 'openenclave-curl'
[100%] Built target libcurl
[100%] Built target dummy
[ 11%] No install step for 'openenclave-curl'
[ 17%] Completed 'openenclave-curl'
[ 47%] Built target openenclave-curl
[ 52%] Performing configure step for 'tests'
loading initial cache file /data/amchamay/openenclave-curl/build/tests-prefix/tmp/tests-cache-.cmake
-- Looking for crypto library - found
-- Looking for dl library - found
-- Configuring done
-- Generating done
-- Build files have been written to: /data/amchamay/openenclave-curl/build/tests-prefix/src/tests-build
[ 58%] Performing build step for 'tests'
[ 55%] Built target tests.enclave
[100%] Built target tests.host
[ 64%] No install step for 'tests'
[ 70%] Performing test step for 'tests'
Running tests...
Test project /data/amchamay/openenclave-curl/build/tests-prefix/src/tests-build
    Start 1: openenclave-curl-tests
1/1 Test #1: openenclave-curl-tests ...........   Passed    1.40 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   1.40 sec
[ 76%] Completed 'tests'
[100%] Built target tests
```