### PR TITLE
Fix cmake to work with OE >=0.13

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -47,10 +47,13 @@ add_custom_target(dummy ALL DEPENDS libcurl)
 
 target_link_libraries(libcurl
     openenclave::oeenclave
+    openenclave::oecryptombedtls
     openenclave::oelibcxx
     openenclave::oehostsock
     openenclave::oehostresolver
     )
+
+target_include_directories(libcurl PUBLIC ${OE_INCLUDEDIR}/openenclave/3rdparty)
 
 target_sources(libcurl PRIVATE stubs_undefined.c)
 


### PR DESCRIPTION
Explicitly include & link mbedtls, since OpenEnclave 0.13 and above no longer does it by default.